### PR TITLE
Fix entitlements and cleanup targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,11 @@ This repository contains the Argio Platform SSO extension for macOS and iOS.
 
 A preconfigured configuration profile is available under `deployment/argio_PSSO.mobileconfig`. Install this profile on managed devices to enable the Argio Platform SSO extension.
 
+## Next steps
+
+1. Clone the repository and open `Scissors.xcodeproj` in Xcode.
+2. Select the scheme `ssoe-ios` or `ssoe-macos` depending on the desired platform.
+3. Configure your signing settings or use the provided team ID `QUR8QTGXNB`.
+4. Build and run the extension on a test device.
+5. Deploy the configuration profile to activate the extension for all users.
+

--- a/Scissors.xcodeproj/project.pbxproj
+++ b/Scissors.xcodeproj/project.pbxproj
@@ -19,8 +19,6 @@
 		767C483C2BBFA53D00AFA32F /* AuthenticationViewController+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767C483A2BBFA53D00AFA32F /* AuthenticationViewController+Shared.swift */; };
                 76E195252BD0BAD0002442A5 /* AuthenticationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E195232BD0BAD0002442A5 /* AuthenticationViewController.swift */; };
                 76E1952A2BD0BD49002442A5 /* AuthenticationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 76E195282BD0BD49002442A5 /* AuthenticationViewController.xib */; };
-                A3D4E698849A8BB7DCDD7147 /* AuthorizationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626E9643F88C4B031E72B19A /* AuthorizationProvider.swift */; };
-                9F501FC759EC64BDDC52E7C0 /* AuthorizationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626E9643F88C4B031E72B19A /* AuthorizationProvider.swift */; };
                 482A41A34683C3B669DFBE9C /* AuthenticationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B734FE3FF7962C6E6436B /* AuthenticationViewController.swift */; };
                 E070DFD191EF6A39DE513F6F /* AuthenticationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D38C1CC0B3138F3DAA64EAED /* AuthenticationViewController.xib */; };
                 B403AFA3DF01A1BDC27EE9BC /* Cookies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7632D5732BBF9CF100CA9DFD /* Cookies.swift */; };
@@ -322,7 +320,6 @@
                                 7632D5752BBF9CF100CA9DFD /* Cookies.swift in Sources */,
                                 76E195252BD0BAD0002442A5 /* AuthenticationViewController.swift in Sources */,
                                 767C483C2BBFA53D00AFA32F /* AuthenticationViewController+Shared.swift in Sources */,
-                                A3D4E698849A8BB7DCDD7147 /* AuthorizationProvider.swift in Sources */,
                         );
                         runOnlyForDeploymentPostprocessing = 0;
                 };
@@ -333,7 +330,6 @@
                                 B403AFA3DF01A1BDC27EE9BC /* Cookies.swift in Sources */,
                                 482A41A34683C3B669DFBE9C /* AuthenticationViewController.swift in Sources */,
                                 F3B3A0A2B1332CBEB61496A2 /* AuthenticationViewController+Shared.swift in Sources */,
-                                9F501FC759EC64BDDC52E7C0 /* AuthorizationProvider.swift in Sources */,
                         );
                         runOnlyForDeploymentPostprocessing = 0;
                 };

--- a/ssoe-ios/ssoe-ios.entitlements
+++ b/ssoe-ios/ssoe-ios.entitlements
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
     <key>com.apple.developer.authentication-services</key>
-    <true/>
+    <string>Extension</string>
 </dict>
 </plist>

--- a/ssoe-macos/ssoe-macos.entitlements
+++ b/ssoe-macos/ssoe-macos.entitlements
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
     <key>com.apple.developer.authentication-services</key>
-    <true/>
+    <string>Extension</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- correct the entitlements for both iOS and macOS extensions
- remove AuthorizationProvider.swift from target build phases
- document the next steps for building and installing the extension

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b4aab4dd883269493dd37e0a9f240